### PR TITLE
fix: 修复登录后白屏

### DIFF
--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -3,6 +3,8 @@ import zh from "./modules/zh";
 import en from "./modules/en";
 
 const i18n = createI18n({
+	//解决登录后白屏的bug
+	legacy: false,
 	locale: "zh",
 	messages: {
 		zh,


### PR DESCRIPTION
代码拉下来后发现登录后白屏，调试器报错
`Uncaught SyntaxError: Not available in legacy mode`
不知道你本地开发有没有这个问题，
随即去百度错误信息得到
在createI18n中添加属性`legacy:false`解决了这个问题

legacy为控制i18n的Composition API 模式
然后我没细看代码所以浅浅提个pr

也不知道解决这个问题没有
 #43 