### PR TITLE
feat: 🚀 新增tabs选项卡右键菜单

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	"devDependencies": {
 		"@commitlint/cli": "^17.0.1",
 		"@commitlint/config-conventional": "^17.0.0",
+		"@howdyjs/mouse-menu": "^2.0.5",
 		"@types/node": "^17.0.31",
 		"@typescript-eslint/eslint-plugin": "^5.22.0",
 		"@typescript-eslint/parser": "^5.22.0",

--- a/src/layouts/components/Tabs/index.vue
+++ b/src/layouts/components/Tabs/index.vue
@@ -1,13 +1,15 @@
 <template>
 	<div class="tabs-box">
 		<div class="tabs-menu">
-			<el-tabs v-model="tabsMenuValue" type="card" @tab-click="tabClick" @tab-remove="tabRemove">
+			<el-tabs v-model="tabsMenuValue" type="card" @tab-click="tabClick" @contextmenu="onContextmenu" @tab-remove="tabRemove">
 				<el-tab-pane v-for="item in tabsMenuList" :key="item.path" :label="item.title" :name="item.path" :closable="item.close">
 					<template #label>
-						<el-icon class="tabs-icon" v-if="item.icon && themeConfig.tabsIcon">
-							<component :is="item.icon"></component>
-						</el-icon>
-						{{ item.title }}
+						<span :page-path="item.path">
+							<el-icon class="tabs-icon" v-if="item.icon && themeConfig.tabsIcon">
+								<component :is="item.icon"></component>
+							</el-icon>
+							{{ item.title }}
+						</span>
 					</template>
 				</el-tab-pane>
 			</el-tabs>
@@ -23,6 +25,7 @@ import { GlobalStore } from "@/stores";
 import { TabsStore } from "@/stores/modules/tabs";
 import { TabsPaneContext } from "element-plus";
 import MoreButton from "./components/MoreButton.vue";
+import { CustomMouseMenu } from "@howdyjs/mouse-menu";
 
 const route = useRoute();
 const router = useRouter();
@@ -60,6 +63,55 @@ const tabClick = (tabItem: TabsPaneContext) => {
 // Remove Tab
 const tabRemove = (activeTabPath: string) => {
 	tabStore.removeTabs(activeTabPath, activeTabPath == route.path);
+};
+
+// tab Right Click
+const onContextmenu = (e: MouseEvent) => {
+	const path = getPagePath(e.target as HTMLElement);
+	if (!path) return;
+	const menuOptions = {
+		menuWrapperCss: {
+			background: "#fff",
+			boxShadow: "0 0 10px #ccc"
+		},
+		menuItemCss: {
+			hoverBackground: document.documentElement.style.getPropertyValue("--el-color-primary-light-9"),
+			hoverLabelColor: document.documentElement.style.getPropertyValue("--el-color-primary"),
+			hoverTipsColor: document.documentElement.style.getPropertyValue("--el-color-primary"),
+			hoverArrowColor: document.documentElement.style.getPropertyValue("--el-color-primary")
+		},
+		menuList: [
+			{
+				label: "关闭左侧",
+				tips: "Left",
+				fn: (path: any) => tabStore.closeLeftTab(path)
+			},
+			{
+				label: "关闭右侧",
+				tips: "Right",
+				fn: (path: any) => tabStore.closeRightTab(path)
+			},
+			{
+				label: "关闭其它",
+				tips: "All",
+				fn: (path: any) => tabStore.closeMultipleTab(path)
+			}
+		]
+	};
+	const { x, y } = e;
+	const ctx = CustomMouseMenu({
+		el: e.currentTarget as HTMLElement,
+		params: path,
+		...menuOptions
+	});
+	ctx.show(x, y);
+	e.preventDefault();
+};
+
+const getPagePath = (target: HTMLElement, depth = 0): any => {
+	if (depth > 3) return null;
+	const pageKey = target.getAttribute("page-path");
+	return pageKey ?? getPagePath(target.parentNode as HTMLElement, ++depth);
 };
 </script>
 

--- a/src/stores/modules/tabs.ts
+++ b/src/stores/modules/tabs.ts
@@ -38,6 +38,16 @@ export const TabsStore = defineStore({
 			this.tabsMenuList = this.tabsMenuList.filter(item => {
 				return item.path === tabsMenuValue || !item.close;
 			});
+		},
+		// Close LeftTab
+		async closeLeftTab(tabsMenuValue?: string) {
+			const index = this.tabsMenuList.findIndex(item => item.path === tabsMenuValue);
+			this.tabsMenuList.splice(1, index - 1);
+		},
+		// CloseRightTab
+		async closeRightTab(tabsMenuValue?: string) {
+			const index = this.tabsMenuList.findIndex(item => item.path === tabsMenuValue);
+			this.tabsMenuList.splice(index + 1);
 		}
 	},
 	persist: piniaPersistConfig("TabsState")


### PR DESCRIPTION
#76 
描述：利用  `@howdyjs/mouse-menu` 插件实现 `tabs` 选项卡右键菜单功能。

测试：
谷歌浏览器（版本号：106.0.5249.121） :heavy_check_mark:
火狐浏览器（版本号：106.0.5）:heavy_check_mark:
edge浏览器（版本号：107.0.1418.35）:heavy_check_mark:




