### PR TITLE
feat: 🚀 新增路由相关功能

### DIFF
--- a/src/assets/json/dynamicRouter.json
+++ b/src/assets/json/dynamicRouter.json
@@ -55,7 +55,24 @@
 						"isFull": false,
 						"isAffix": false,
 						"isKeepAlive": true
-					}
+					},
+					"children": [
+						{
+							"path": "/proTable/useProTable/detail/:id",
+							"name": "useProTableDetail",
+							"component": "/proTable/useProTable/detail",
+							"meta": {
+								"icon": "Menu",
+								"title": "ProTable 详情",
+								"activeMenu": "/proTable/useProTable",
+								"isLink": "",
+								"isHide": true,
+								"isFull": false,
+								"isAffix": false,
+								"isKeepAlive": true
+							}
+						}
+					]
 				},
 				{
 					"path": "/proTable/useTreeFilter",

--- a/src/layouts/LayoutClassic/index.vue
+++ b/src/layouts/LayoutClassic/index.vue
@@ -49,7 +49,7 @@ import ToolBarRight from "@/layouts/components/Header/ToolBarRight.vue";
 const route = useRoute();
 const authStore = AuthStore();
 const globalStore = GlobalStore();
-const activeMenu = computed(() => route.path);
+const activeMenu = computed(() => (route.meta.activeMenu ? route.meta.activeMenu : route.path));
 const menuList = computed(() => authStore.showMenuListGet);
 const isCollapse = computed(() => globalStore.themeConfig.isCollapse);
 </script>

--- a/src/layouts/LayoutColumns/index.vue
+++ b/src/layouts/LayoutColumns/index.vue
@@ -64,7 +64,7 @@ const route = useRoute();
 const router = useRouter();
 const authStore = AuthStore();
 const globalStore = GlobalStore();
-const activeMenu = computed(() => route.path);
+const activeMenu = computed(() => (route.meta.activeMenu ? route.meta.activeMenu : route.path));
 const menuList = computed(() => authStore.showMenuListGet);
 const isCollapse = computed(() => globalStore.themeConfig.isCollapse);
 

--- a/src/layouts/LayoutTransverse/index.vue
+++ b/src/layouts/LayoutTransverse/index.vue
@@ -53,7 +53,7 @@ import SubMenu from "@/layouts/components/Menu/SubMenu.vue";
 const route = useRoute();
 const router = useRouter();
 const authStore = AuthStore();
-const activeMenu = computed(() => route.path);
+const activeMenu = computed(() => (route.meta.activeMenu ? route.meta.activeMenu : route.path));
 const menuList = computed(() => authStore.showMenuListGet);
 
 const handleClickMenu = (subItem: Menu.MenuOptions) => {

--- a/src/layouts/LayoutVertical/index.vue
+++ b/src/layouts/LayoutVertical/index.vue
@@ -46,7 +46,7 @@ import SubMenu from "@/layouts/components/Menu/SubMenu.vue";
 const route = useRoute();
 const authStore = AuthStore();
 const globalStore = GlobalStore();
-const activeMenu = computed(() => route.path);
+const activeMenu = computed(() => (route.meta.activeMenu ? route.meta.activeMenu : route.path));
 const menuList = computed(() => authStore.showMenuListGet);
 const isCollapse = computed(() => globalStore.themeConfig.isCollapse);
 </script>

--- a/src/layouts/components/Header/components/Breadcrumb.vue
+++ b/src/layouts/components/Header/components/Breadcrumb.vue
@@ -1,24 +1,26 @@
 <template>
 	<el-breadcrumb :separator-icon="ArrowRight">
 		<transition-group name="breadcrumb" mode="out-in">
-			<!-- 首页面包屑不要可以直接删除 🙅‍♀️ -->
-			<el-breadcrumb-item :to="{ path: HOME_URL }" :key="HOME_URL" v-if="breadcrumbList[0].meta.title !== '首页'">
-				<div class="breadcrumb-item">
-					<el-icon class="breadcrumb-icon" v-if="themeConfig.breadcrumbIcon">
-						<HomeFilled />
-					</el-icon>
-					<span class="breadcrumb-title">首页</span>
-				</div>
-			</el-breadcrumb-item>
-			<!-- other -->
-			<el-breadcrumb-item v-for="item in breadcrumbList" :key="item.path" :to="{ path: item.path }">
-				<div class="breadcrumb-item">
-					<el-icon class="breadcrumb-icon" v-if="item.meta.icon && themeConfig.breadcrumbIcon">
-						<component :is="item.meta.icon"></component>
-					</el-icon>
-					<span class="breadcrumb-title">{{ item.meta.title }}</span>
-				</div>
-			</el-breadcrumb-item>
+			<template v-if="breadcrumbList">
+				<!-- 首页面包屑不要可以直接删除 🙅‍♀️ -->
+				<el-breadcrumb-item :to="{ path: HOME_URL }" :key="HOME_URL" v-if="breadcrumbList[0].meta.title !== '首页'">
+					<div class="breadcrumb-item">
+						<el-icon class="breadcrumb-icon" v-if="themeConfig.breadcrumbIcon">
+							<HomeFilled />
+						</el-icon>
+						<span class="breadcrumb-title">首页</span>
+					</div>
+				</el-breadcrumb-item>
+				<!-- other -->
+				<el-breadcrumb-item v-for="item in breadcrumbList" :key="item.path" :to="{ path: item.path }">
+					<div class="breadcrumb-item">
+						<el-icon class="breadcrumb-icon" v-if="item.meta.icon && themeConfig.breadcrumbIcon">
+							<component :is="item.meta.icon"></component>
+						</el-icon>
+						<span class="breadcrumb-title">{{ item.meta.title }}</span>
+					</div>
+				</el-breadcrumb-item>
+			</template>
 		</transition-group>
 	</el-breadcrumb>
 </template>
@@ -35,7 +37,7 @@ const route = useRoute();
 const authStore = AuthStore();
 const globalStore = GlobalStore();
 const themeConfig = computed(() => globalStore.themeConfig);
-const breadcrumbList = computed(() => authStore.breadcrumbListGet[route.path]);
+const breadcrumbList = computed(() => authStore.breadcrumbListGet[route.matched[route.matched.length - 1].path]);
 </script>
 
 <style scoped lang="scss">

--- a/src/layouts/components/Tabs/components/MoreButton.vue
+++ b/src/layouts/components/Tabs/components/MoreButton.vue
@@ -55,12 +55,12 @@ const maximize = () => {
 // Close Current
 const closeCurrentTab = () => {
 	if (route.meta.isAffix) return;
-	tabStore.removeTabs(route.path);
+	tabStore.removeTabs(route.fullPath);
 };
 
 // Close Other
 const closeOtherTab = () => {
-	tabStore.closeMultipleTab(route.path);
+	tabStore.closeMultipleTab(route.fullPath);
 };
 
 // Close All

--- a/src/layouts/components/Tabs/index.vue
+++ b/src/layouts/components/Tabs/index.vue
@@ -29,19 +29,19 @@ const router = useRouter();
 const tabStore = TabsStore();
 const globalStore = GlobalStore();
 
-const tabsMenuValue = ref(route.path);
+const tabsMenuValue = ref(route.fullPath);
 const tabsMenuList = computed(() => tabStore.tabsMenuList);
 const themeConfig = computed(() => globalStore.themeConfig);
 
 // 监听路由的变化（防止浏览器后退/前进不变化 tabsMenuValue）
 watch(
-	() => route.path,
+	() => route.fullPath,
 	() => {
-		tabsMenuValue.value = route.path;
+		tabsMenuValue.value = route.fullPath;
 		const tabsParams = {
 			icon: route.meta.icon as string,
 			title: route.meta.title as string,
-			path: route.path,
+			path: route.fullPath,
 			close: !route.meta.isAffix
 		};
 		tabStore.addTabs(tabsParams);
@@ -59,7 +59,7 @@ const tabClick = (tabItem: TabsPaneContext) => {
 
 // Remove Tab
 const tabRemove = (activeTabPath: string) => {
-	tabStore.removeTabs(activeTabPath, activeTabPath == route.path);
+	tabStore.removeTabs(activeTabPath, activeTabPath == route.fullPath);
 };
 </script>
 

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -11,6 +11,7 @@ declare namespace Menu {
 	interface MetaProps {
 		icon: string;
 		title: string;
+		activeMenu: string;
 		isLink: string;
 		isHide: boolean;
 		isFull: boolean;

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -255,7 +255,7 @@ export function getAllBreadcrumbList(menuList: Menu.MenuOptions[]) {
 	let handleBreadcrumbList: { [key: string]: any } = {};
 	const loop = (menuItem: Menu.MenuOptions) => {
 		if (menuItem?.children?.length) menuItem.children.forEach(item => loop(item));
-		else handleBreadcrumbList[menuItem.path] = getCurrentBreadcrumb(menuItem.path, menuList);
+		handleBreadcrumbList[menuItem.path] = getCurrentBreadcrumb(menuItem.path, menuList);
 	};
 	menuList.forEach(item => loop(item));
 	return handleBreadcrumbList;

--- a/src/views/proTable/useProTable/detail.vue
+++ b/src/views/proTable/useProTable/detail.vue
@@ -1,0 +1,14 @@
+<template>
+	<div class="card">
+		<p>proTable detail</p>
+		<p>params:{{ route.params }}</p>
+		<p>query:{{ route.query }}</p>
+	</div>
+</template>
+<script setup lang="ts">
+import { useRoute } from "vue-router";
+
+const route = useRoute();
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/views/proTable/useProTable/index.vue
+++ b/src/views/proTable/useProTable/index.vue
@@ -16,6 +16,7 @@
 				<el-button type="danger" :icon="Delete" plain @click="batchDelete(scope.selectedListIds)" :disabled="!scope.isSelected">
 					批量删除用户
 				</el-button>
+				<el-button type="primary" plain @click="toDetail">页面详情</el-button>
 			</template>
 			<!-- Expand -->
 			<template #expand="scope">
@@ -49,6 +50,7 @@
 <script setup lang="tsx" name="useProTable">
 import { ref, reactive } from "vue";
 import { ElMessage } from "element-plus";
+import { useRouter } from "vue-router";
 import { User } from "@/api/interface";
 import { ColumnProps } from "@/components/ProTable/interface";
 import { useHandleData } from "@/hooks/useHandleData";
@@ -71,6 +73,12 @@ import {
 	getUserGender
 } from "@/api/modules/user";
 
+const router = useRouter();
+
+// 跳转详情页
+const toDetail = () => {
+	router.push(`/proTable/useProTable/detail/${Math.random()}?params=detail-page`);
+};
 // 获取 ProTable 元素，调用其获取刷新数据方法（还能获取到当前查询参数，方便导出携带参数）
 const proTable = ref();
 


### PR DESCRIPTION
1、当菜单isHide=true时，可设置activeMenu字段来指定高亮菜单（[#71](https://github.com/HalseySpicy/Geeker-Admin/issues/71)）
2、当路由以 ?xx=xx 方式跳转时，点击分页标签，现在会保留路由参数（[#72](https://github.com/HalseySpicy/Geeker-Admin/issues/72)）
3、支持路由参数"/example/:id"（#[49](https://github.com/HalseySpicy/Geeker-Admin/issues/49)）
