### PR TITLE
chore: 🔨 修改commitlint的ignores配置

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,7 +2,7 @@
 /** @type {import('cz-git').UserConfig} */
 
 module.exports = {
-	ignores: [commit => commit.includes("init")],
+	ignores: [commit => commit === "init"],
 	extends: ["@commitlint/config-conventional"],
 	rules: {
 		// @see: https://commitlint.js.org/#/reference-rules


### PR DESCRIPTION
修改 commitlint的ignores配置时,使用includes匹配会导致后续部分提交 xxx init 就会跳过commitlint,替换成全等判断 
防止误输入init并直接执行git commit 提交不符合commitlint规范的提交记录