### PR TITLE
Upload video typefeat: 🚀 新增文件上传-视频类型

### DIFF
--- a/src/components/Upload/Img.vue
+++ b/src/components/Upload/Img.vue
@@ -154,7 +154,6 @@ const editImg = () => {
 const beforeUpload: UploadProps["beforeUpload"] = rawFile => {
 	const imgSize = rawFile.size / 1024 / 1024 < props.fileSize;
 	const imgType = props.fileType;
-
 	// 验证fileType传入'image/*','video/*'等参数格式
 	if (
 		!imgType.includes(rawFile.type as FileTypes) ||

--- a/src/components/Upload/Img.vue
+++ b/src/components/Upload/Img.vue
@@ -64,7 +64,11 @@ type FileTypes =
 	| "image/svg+xml"
 	| "image/tiff"
 	| "image/webp"
-	| "image/x-icon";
+	| "image/x-icon"
+	| "video/mp4"
+	| "video/avi"
+	| "video/wmv"
+	| "video/rm";
 
 interface UploadFileProps {
 	imageUrl: string; // 图片地址 ==> 必传
@@ -72,7 +76,7 @@ interface UploadFileProps {
 	drag?: boolean; // 是否支持拖拽上传 ==> 非必传（默认为 true）
 	disabled?: boolean; // 是否禁用上传组件 ==> 非必传（默认为 false）
 	fileSize?: number; // 图片大小限制 ==> 非必传（默认为 5M）
-	fileType?: FileTypes[]; // 图片类型限制 ==> 非必传（默认为 ["image/jpeg", "image/png", "image/gif"]）
+	fileType?: Array<FileTypes | string>; // 图片类型限制 ==> 非必传（默认为 ["image/jpeg", "image/png", "image/gif"]）
 	height?: string; // 组件高度 ==> 非必传（默认为 150px）
 	width?: string; // 组件宽度 ==> 非必传（默认为 150px）
 	borderRadius?: string; // 组件边框圆角 ==> 非必传（默认为 8px）
@@ -150,7 +154,12 @@ const editImg = () => {
 const beforeUpload: UploadProps["beforeUpload"] = rawFile => {
 	const imgSize = rawFile.size / 1024 / 1024 < props.fileSize;
 	const imgType = props.fileType;
-	if (!imgType.includes(rawFile.type as FileTypes))
+
+	// 验证fileType传入'image/*','video/*'等参数格式
+	if (
+		!imgType.includes(rawFile.type as FileTypes) ||
+		!imgType.some(_ => _.indexOf("/*") > -1 && _.split("/*")[0] === rawFile.type.split("/")[0])
+	)
 		ElNotification({
 			title: "温馨提示",
 			message: "上传图片不符合所需的格式！",

--- a/src/components/Upload/Imgs.vue
+++ b/src/components/Upload/Imgs.vue
@@ -60,7 +60,11 @@ type FileTypes =
 	| "image/svg+xml"
 	| "image/tiff"
 	| "image/webp"
-	| "image/x-icon";
+	| "image/x-icon"
+	| "video/mp4"
+	| "video/avi"
+	| "video/wmv"
+	| "video/rm";
 
 interface UploadFileProps {
 	fileList: UploadUserFile[];
@@ -69,7 +73,7 @@ interface UploadFileProps {
 	disabled?: boolean; // 是否禁用上传组件 ==> 非必传（默认为 false）
 	limit?: number; // 最大图片上传数 ==> 非必传（默认为 5张）
 	fileSize?: number; // 图片大小限制 ==> 非必传（默认为 5M）
-	fileType?: FileTypes[]; // 图片类型限制 ==> 非必传（默认为 ["image/jpeg", "image/png", "image/gif"]）
+	fileType?: Array<FileTypes | string>; // 图片类型限制 ==> 非必传（默认为 ["image/jpeg", "image/png", "image/gif"]）
 	height?: string; // 组件高度 ==> 非必传（默认为 150px）
 	width?: string; // 组件宽度 ==> 非必传（默认为 150px）
 	borderRadius?: string; // 组件边框圆角 ==> 非必传（默认为 8px）
@@ -105,7 +109,11 @@ const fileList = ref<UploadUserFile[]>(props.fileList);
 const beforeUpload: UploadProps["beforeUpload"] = rawFile => {
 	const imgSize = rawFile.size / 1024 / 1024 < props.fileSize;
 	const imgType = props.fileType;
-	if (!imgType.includes(rawFile.type as FileTypes))
+	// 验证fileType传入'image/*','video/*'等参数格式
+	if (
+		!imgType.includes(rawFile.type as FileTypes) ||
+		!imgType.some(_ => _.indexOf("/*") > -1 && _.split("/*")[0] === rawFile.type.split("/")[0])
+	)
 		ElNotification({
 			title: "温馨提示",
 			message: "上传图片不符合所需的格式！",


### PR DESCRIPTION
1.新增文件上传-视频类型(常用类型)
2.文件上传-图片类型限制可自定义Array<FileTypes | string>
3.验证fileType传入'image/*','video/*'等参数格式