### PR TITLE
fix: 🧩 当有请求参数时，修改tab标题错误

### DIFF
--- a/src/stores/modules/tabs.ts
+++ b/src/stores/modules/tabs.ts
@@ -40,7 +40,7 @@ export const useTabsStore = defineStore({
     },
     // Set Tabs Title
     async setTabsTitle(title: string) {
-      const nowFullPath = location.hash.substring(1);
+			const nowFullPath = location.hash.substring(1, location.hash.indexOf("?"));
       this.tabsMenuList.forEach(item => {
         if (item.path == nowFullPath) item.title = title;
       });


### PR DESCRIPTION
当有请求参数时`const nowFullPath = location.hash.substring(1)`会包含请求参数导致找不到tab，更改为`const nowFullPath = location.hash.substring(1, location.hash.indexOf("?"))`可解决