### PR TITLE
fix: Breadcrumb no icon title alignment center

### DIFF
--- a/src/layouts/components/Header/components/Breadcrumb.vue
+++ b/src/layouts/components/Header/components/Breadcrumb.vue
@@ -92,6 +92,7 @@ const onBreadcrumbClick = (item: Menu.MenuOptions, index: number) => {
 .no-icon {
   .el-breadcrumb {
     .el-breadcrumb__item {
+      float: left;
       top: -2px;
       :deep(.el-breadcrumb__separator) {
         top: 2px;

--- a/src/layouts/components/Header/components/Breadcrumb.vue
+++ b/src/layouts/components/Header/components/Breadcrumb.vue
@@ -3,7 +3,11 @@
     <el-breadcrumb :separator-icon="ArrowRight">
       <transition-group name="breadcrumb">
         <el-breadcrumb-item v-for="(item, index) in breadcrumbList" :key="item.path">
-          <div class="el-breadcrumb__inner is-link" @click="onBreadcrumbClick(item, index)">
+          <div
+            class="el-breadcrumb__inner is-link"
+            :class="{ 'no-icon': !item.meta.icon }"
+            @click="onBreadcrumbClick(item, index)"
+          >
             <el-icon v-show="item.meta.icon && globalStore.breadcrumbIcon" class="breadcrumb-icon">
               <component :is="item.meta.icon"></component>
             </el-icon>
@@ -54,6 +58,9 @@ const onBreadcrumbClick = (item: Menu.MenuOptions, index: number) => {
       position: relative;
       display: inline-block;
       float: none;
+      .no-icon {
+        float: inline-end;
+      }
       .el-breadcrumb__inner {
         display: inline-flex;
         &.is-link {

--- a/src/layouts/components/Header/components/Breadcrumb.vue
+++ b/src/layouts/components/Header/components/Breadcrumb.vue
@@ -8,7 +8,7 @@
             :class="{ 'no-icon': !item.meta.icon }"
             @click="onBreadcrumbClick(item, index)"
           >
-            <el-icon v-show="item.meta.icon && globalStore.breadcrumbIcon" class="breadcrumb-icon">
+            <el-icon v-if="item.meta.icon && globalStore.breadcrumbIcon" class="breadcrumb-icon">
               <component :is="item.meta.icon"></component>
             </el-icon>
             <span class="breadcrumb-title">{{ item.meta.title }}</span>

--- a/src/layouts/components/Menu/SubMenu.vue
+++ b/src/layouts/components/Menu/SubMenu.vue
@@ -2,19 +2,19 @@
   <template v-for="subItem in menuList" :key="subItem.path">
     <el-sub-menu v-if="subItem.children?.length" :index="subItem.path">
       <template #title>
-        <el-icon>
+        <el-icon v-if="subItem.meta.icon">
           <component :is="subItem.meta.icon"></component>
         </el-icon>
-        <span class="sle">{{ subItem.meta.title }}</span>
+        <span class="sle" :class="{ 'no-icon': !subItem.meta.icon }">{{ subItem.meta.title }}</span>
       </template>
       <SubMenu :menu-list="subItem.children" />
     </el-sub-menu>
     <el-menu-item v-else :index="subItem.path" @click="handleClickMenu(subItem)">
-      <el-icon>
+      <el-icon v-if="subItem.meta.icon">
         <component :is="subItem.meta.icon"></component>
       </el-icon>
       <template #title>
-        <span class="sle">{{ subItem.meta.title }}</span>
+        <span class="sle" :class="{ 'no-icon': !subItem.meta.icon }">{{ subItem.meta.title }}</span>
       </template>
     </el-menu-item>
   </template>
@@ -87,5 +87,8 @@ const handleClickMenu = (subItem: Menu.MenuOptions) => {
   #driver-highlighted-element-stage {
     background-color: #606266 !important;
   }
+}
+.no-icon {
+  padding-left: 10px;
 }
 </style>

--- a/src/layouts/components/Tabs/index.vue
+++ b/src/layouts/components/Tabs/index.vue
@@ -4,7 +4,7 @@
       <el-tabs v-model="tabsMenuValue" type="card" @tab-click="tabClick" @tab-remove="tabRemove">
         <el-tab-pane v-for="item in tabsMenuList" :key="item.path" :label="item.title" :name="item.path" :closable="item.close">
           <template #label>
-            <el-icon v-show="item.icon && tabsIcon" class="tabs-icon">
+            <el-icon v-if="item.icon && tabsIcon" class="tabs-icon">
               <component :is="item.icon"></component>
             </el-icon>
             {{ item.title }}


### PR DESCRIPTION
修复2个问题；

1、头部导航，二级菜单无图标时，文字不对齐
ref: https://github.com/HalseySpicy/Geeker-Admin/issues/287

2、修复 el-icon 无图标时，控制台输出告警
Invalid vnode type when creating vnode: " at <ElIcon>"
<img width="914" alt="iShot_2023-08-15_21 24 41" src="https://github.com/HalseySpicy/Geeker-Admin/assets/11418363/37bef6b3-7e8d-475d-ae86-c9a370db0ba0">

