### PR TITLE
fix: 修复proTable不支持formatter属性的问题

### DIFF
--- a/src/components/ProTable/components/TableColumn.vue
+++ b/src/components/ProTable/components/TableColumn.vue
@@ -6,6 +6,7 @@
 import { inject, ref, useSlots } from "vue";
 import { ColumnProps, RenderScope, HeaderRenderScope } from "@/components/ProTable/interface";
 import { filterEnum, formatValue, handleProp, handleRowAccordingToProp } from "@/utils";
+import { isFunction } from "@/utils/is";
 
 defineProps<{ column: ColumnProps }>();
 
@@ -15,6 +16,9 @@ const enumMap = inject("enumMap", ref(new Map()));
 
 // 渲染表格数据
 const renderCellData = (item: ColumnProps, scope: RenderScope<any>) => {
+  if (isFunction(item.formatter)) {
+    return item.formatter(scope.row, scope.column, handleRowAccordingToProp(scope.row, item.prop!), scope.$index);
+  }
   return enumMap.value.get(item.prop) && item.isFilterEnum
     ? filterEnum(handleRowAccordingToProp(scope.row, item.prop!), enumMap.value.get(item.prop)!, item.fieldNames)
     : formatValue(handleRowAccordingToProp(scope.row, item.prop!));


### PR DESCRIPTION
proTable应该支持el-table以及el-table-column的所有属性
目前对el-table-column传入fomatter属性则不会对列内容进行格式化处理
```javascript
// 渲染表格数据
const renderCellData = (item: ColumnProps, scope: RenderScope<any>) => {
  return enumMap.value.get(item.prop) && item.isFilterEnum
    ? filterEnum(handleRowAccordingToProp(scope.row, item.prop!), enumMap.value.get(item.prop)!, item.fieldNames)
    : formatValue(handleRowAccordingToProp(scope.row, item.prop!));
};
```
修复后如下：

```javascript
// 渲染表格数据
const renderCellData = (item: ColumnProps, scope: RenderScope<any>) => {
  if (isFunction(item.formatter)) {
    return item.formatter(scope.row, scope.column, handleRowAccordingToProp(scope.row, item.prop!), scope.$index);
  }
  return enumMap.value.get(item.prop) && item.isFilterEnum
    ? filterEnum(handleRowAccordingToProp(scope.row, item.prop!), enumMap.value.get(item.prop)!, item.fieldNames)
    : formatValue(handleRowAccordingToProp(scope.row, item.prop!));
};
`