### PR TITLE
fix: 修复keepalive页面缓存bug

### DIFF
--- a/src/routers/modules/dynamicRouter.ts
+++ b/src/routers/modules/dynamicRouter.ts
@@ -37,7 +37,9 @@ export const initDynamicRouter = async () => {
     authStore.flatMenuListGet.forEach(item => {
       item.children && delete item.children;
       if (item.component && typeof item.component == "string") {
-        item.component = modules["/src/views" + item.component + ".vue"];
+        const component = modules["/src/views" + item.component + ".vue"];
+        // 动态加载组建的name，配合keep-aliva缓存页面，确保切换标签时，页面内容不变（解决编辑，新增页面公用同一组件的情况）
+        item.component = () => component().then((com: any) => ({ ...com.default, name: item.name }));
       }
       if (item.meta.isFull) {
         router.addRoute(item as unknown as RouteRecordRaw);

--- a/src/stores/modules/tabs.ts
+++ b/src/stores/modules/tabs.ts
@@ -20,7 +20,7 @@ export const useTabsStore = defineStore({
       }
       // add keepalive
       if (!keepAliveStore.keepAliveName.includes(tabItem.name) && tabItem.isKeepAlive) {
-        keepAliveStore.addKeepAliveName(tabItem.path);
+        keepAliveStore.addKeepAliveName(tabItem.name);
       }
     },
     // Remove Tabs


### PR DESCRIPTION
1. 修复keepAliveName插入成path而不是name的bug
2. 动态加载组件的name，配合keep-aliva缓存页面，确保切换标签时，页面内容不变（解决编辑，新增页面公用同一组件的情况）