### PR TITLE
fix: 修复keepalive页面缓存bug

### DIFF
--- a/src/layouts/components/Main/index.vue
+++ b/src/layouts/components/Main/index.vue
@@ -5,7 +5,7 @@
     <router-view v-slot="{ Component, route }">
       <transition appear name="fade-transform" mode="out-in">
         <keep-alive :include="keepAliveName">
-          <component :is="createComponentWrapper(Component, route)" v-if="isRouterShow" :key="route.fullPath" />
+          <component :is="Component" v-if="isRouterShow" :key="route.fullPath" />
         </keep-alive>
       </transition>
     </router-view>
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeUnmount, provide, watch, h } from "vue";
+import { ref, onBeforeUnmount, provide, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useDebounceFn } from "@vueuse/core";
 import { useGlobalStore } from "@/stores/modules/global";
@@ -35,19 +35,6 @@ const { keepAliveName } = storeToRefs(keepAliveStore);
 const isRouterShow = ref(true);
 const refreshCurrentPage = (val: boolean) => (isRouterShow.value = val);
 provide("refresh", refreshCurrentPage);
-
-// 解决详情页 keep-alive 问题
-const wrapperMap = new Map();
-function createComponentWrapper(component, route) {
-  if (!component) return;
-  const wrapperName = route.fullPath;
-  let wrapper = wrapperMap.get(wrapperName);
-  if (!wrapper) {
-    wrapper = { name: wrapperName, render: () => h(component) };
-    wrapperMap.set(wrapperName, wrapper);
-  }
-  return h(wrapper);
-}
 
 // 监听当前页面是否最大化，动态添加 class
 watch(

--- a/src/layouts/components/Tabs/components/MoreButton.vue
+++ b/src/layouts/components/Tabs/components/MoreButton.vue
@@ -49,10 +49,10 @@ const keepAliveStore = useKeepAliveStore();
 const refreshCurrentPage: Function = inject("refresh") as Function;
 const refresh = () => {
   setTimeout(() => {
-    route.meta.isKeepAlive && keepAliveStore.removeKeepAliveName(route.fullPath as string);
+    route.meta.isKeepAlive && keepAliveStore.removeKeepAliveName(route.name as string);
     refreshCurrentPage(false);
     nextTick(() => {
-      route.meta.isKeepAlive && keepAliveStore.addKeepAliveName(route.fullPath as string);
+      route.meta.isKeepAlive && keepAliveStore.addKeepAliveName(route.name as string);
       refreshCurrentPage(true);
     });
   }, 0);

--- a/src/routers/modules/dynamicRouter.ts
+++ b/src/routers/modules/dynamicRouter.ts
@@ -37,7 +37,9 @@ export const initDynamicRouter = async () => {
     authStore.flatMenuListGet.forEach(item => {
       item.children && delete item.children;
       if (item.component && typeof item.component == "string") {
-        item.component = modules["/src/views" + item.component + ".vue"];
+        const component = modules["/src/views" + item.component + ".vue"];
+        // 动态加载组建的name，配合keep-aliva缓存页面，确保切换标签时，页面内容不变（解决编辑，新增页面公用同一组件的情况）
+        item.component = () => component().then((com: any) => ({ ...com.default, name: item.name }));
       }
       if (item.meta.isFull) {
         router.addRoute(item as unknown as RouteRecordRaw);

--- a/src/routers/modules/dynamicRouter.ts
+++ b/src/routers/modules/dynamicRouter.ts
@@ -38,7 +38,7 @@ export const initDynamicRouter = async () => {
       item.children && delete item.children;
       if (item.component && typeof item.component == "string") {
         const component = modules["/src/views" + item.component + ".vue"];
-        // 动态加载组建的name，配合keep-aliva缓存页面，确保切换标签时，页面内容不变（解决编辑，新增页面公用同一组件的情况）
+        // 动态加载组件的name，配合keep-aliva缓存页面，确保切换标签时，页面内容不变（解决编辑，新增页面共用同一组件的情况）
         item.component = () => component().then((com: any) => ({ ...com.default, name: item.name }));
       }
       if (item.meta.isFull) {

--- a/src/stores/modules/tabs.ts
+++ b/src/stores/modules/tabs.ts
@@ -20,7 +20,7 @@ export const useTabsStore = defineStore({
       }
       // add keepalive
       if (!keepAliveStore.keepAliveName.includes(tabItem.name) && tabItem.isKeepAlive) {
-        keepAliveStore.addKeepAliveName(tabItem.path);
+        keepAliveStore.addKeepAliveName(tabItem.name);
       }
     },
     // Remove Tabs

--- a/src/stores/modules/tabs.ts
+++ b/src/stores/modules/tabs.ts
@@ -35,7 +35,7 @@ export const useTabsStore = defineStore({
       }
       // remove keepalive
       const tabItem = this.tabsMenuList.find(item => item.path === tabPath);
-      tabItem?.isKeepAlive && keepAliveStore.removeKeepAliveName(tabItem.path);
+      tabItem?.isKeepAlive && keepAliveStore.removeKeepAliveName(tabItem.name);
       // set tabs
       this.tabsMenuList = this.tabsMenuList.filter(item => item.path !== tabPath);
     },
@@ -50,7 +50,7 @@ export const useTabsStore = defineStore({
       }
       // set keepalive
       const KeepAliveList = this.tabsMenuList.filter(item => item.isKeepAlive);
-      keepAliveStore.setKeepAliveName(KeepAliveList.map(item => item.path));
+      keepAliveStore.setKeepAliveName(KeepAliveList.map(item => item.name));
     },
     // Close MultipleTab
     async closeMultipleTab(tabsMenuValue?: string) {
@@ -59,7 +59,7 @@ export const useTabsStore = defineStore({
       });
       // set keepalive
       const KeepAliveList = this.tabsMenuList.filter(item => item.isKeepAlive);
-      keepAliveStore.setKeepAliveName(KeepAliveList.map(item => item.path));
+      keepAliveStore.setKeepAliveName(KeepAliveList.map(item => item.name));
     },
     // Set Tabs
     async setTabs(tabsMenuList: TabsMenuProps[]) {

--- a/src/stores/modules/tabs.ts
+++ b/src/stores/modules/tabs.ts
@@ -33,11 +33,10 @@ export const useTabsStore = defineStore({
           router.push(nextTab.path);
         });
       }
-      // remove keepalive
-      const tabItem = this.tabsMenuList.find(item => item.path === tabPath);
-      tabItem?.isKeepAlive && keepAliveStore.removeKeepAliveName(tabItem.name);
       // set tabs
       this.tabsMenuList = this.tabsMenuList.filter(item => item.path !== tabPath);
+      // set keepalive
+      this.setKeepAliveName();
     },
     // Close Tabs On Side
     async closeTabsOnSide(path: string, type: "left" | "right") {
@@ -49,17 +48,14 @@ export const useTabsStore = defineStore({
         });
       }
       // set keepalive
-      const KeepAliveList = this.tabsMenuList.filter(item => item.isKeepAlive);
-      keepAliveStore.setKeepAliveName(KeepAliveList.map(item => item.name));
+      this.setKeepAliveName();
     },
     // Close MultipleTab
     async closeMultipleTab(tabsMenuValue?: string) {
       this.tabsMenuList = this.tabsMenuList.filter(item => {
         return item.path === tabsMenuValue || !item.close;
       });
-      // set keepalive
-      const KeepAliveList = this.tabsMenuList.filter(item => item.isKeepAlive);
-      keepAliveStore.setKeepAliveName(KeepAliveList.map(item => item.name));
+      this.setKeepAliveName();
     },
     // Set Tabs
     async setTabs(tabsMenuList: TabsMenuProps[]) {
@@ -70,6 +66,12 @@ export const useTabsStore = defineStore({
       this.tabsMenuList.forEach(item => {
         if (item.path == getUrlWithParams()) item.title = title;
       });
+    },
+    // Set keepalive
+    async setKeepAliveName() {
+      // set keepalive
+      const KeepAliveList = this.tabsMenuList.filter(item => item.isKeepAlive);
+      keepAliveStore.setKeepAliveName(Array.from(new Set(KeepAliveList.map(item => item.name))));
     }
   },
   persist: piniaPersistConfig("geeker-tabs")

--- a/src/views/assembly/tabs/index.vue
+++ b/src/views/assembly/tabs/index.vue
@@ -47,10 +47,10 @@ const keepAliveStore = useKeepAliveStore();
 const refreshCurrentPage: Function = inject("refresh") as Function;
 const refresh = () => {
   setTimeout(() => {
-    route.meta.isKeepAlive && keepAliveStore.removeKeepAliveName(route.fullPath as string);
+    route.meta.isKeepAlive && keepAliveStore.removeKeepAliveName(route.name as string);
     refreshCurrentPage(false);
     nextTick(() => {
-      route.meta.isKeepAlive && keepAliveStore.addKeepAliveName(route.fullPath as string);
+      route.meta.isKeepAlive && keepAliveStore.addKeepAliveName(route.name as string);
       refreshCurrentPage(true);
     });
   }, 0);


### PR DESCRIPTION
之前的修复并不是从根本上解决问题，keepAlive需要component的name配合，所以应该在初始化动态添加component的name
配合KeepAliveState来保证组件的动态keepAlive实现，一共有以下修复：
1.  删除之前的错误修复
2. 修复keepAliveName插入成path而不是name的bug
3. 动态加载组件的name，配合keep-aliva缓存页面，确保切换标签时，页面内容不变（解决编辑，新增页面公用同一组件的情况）