### PR TITLE
fix: 🧩 fix _children column the prop option is required

### DIFF
--- a/src/components/ProTable/components/TableColumn.vue
+++ b/src/components/ProTable/components/TableColumn.vue
@@ -40,13 +40,13 @@ const RenderTableColumn = (item: ColumnProps) => {
             default: (scope: RenderScope<any>) => {
               if (item._children) return item._children.map(child => RenderTableColumn(child));
               if (item.render) return item.render(scope);
-              if (slots[handleProp(item.prop!)]) return slots[handleProp(item.prop!)]!(scope);
+              if (item.prop && slots[handleProp(item.prop)]) return slots[handleProp(item.prop)]!(scope);
               if (item.tag) return <el-tag type={getTagType(item, scope)}>{renderCellData(item, scope)}</el-tag>;
               return renderCellData(item, scope);
             },
             header: (scope: HeaderRenderScope<any>) => {
               if (item.headerRender) return item.headerRender(scope);
-              if (slots[`${handleProp(item.prop!)}Header`]) return slots[`${handleProp(item.prop!)}Header`]!(scope);
+              if (item.prop && slots[`${handleProp(item.prop)}Header`]) return slots[`${handleProp(item.prop)}Header`]!(scope);
               return item.label;
             }
           }}

--- a/src/components/ProTable/index.vue
+++ b/src/components/ProTable/index.vue
@@ -67,7 +67,7 @@
           </template>
         </el-table-column>
         <!-- other -->
-        <TableColumn v-if="!item.type && item.prop && item.isShow" :column="item">
+        <TableColumn v-else :column="item">
           <template v-for="slot in Object.keys($slots)" #[slot]="scope">
             <slot :name="slot" v-bind="scope" />
           </template>


### PR DESCRIPTION
该修复针对拥有 _children 的行中 prop 应该不是必填的

before: `{ prop: '需要一些占位符才能显示', _children: [] }`
now: `{ _children: [] }`