### PR TITLE
fix: 修复页面在包含ProTable组建的页面时，首次修改组件大小报错

### DIFF
--- a/src/components/ProTable/components/Pagination.vue
+++ b/src/components/ProTable/components/Pagination.vue
@@ -6,6 +6,7 @@
     :page-size="pageable.pageSize"
     :page-sizes="[10, 25, 50, 100]"
     :total="pageable.total"
+    :size="globalStore?.assemblySize ?? 'default'"
     layout="total, sizes, prev, pager, next, jumper"
     @size-change="handleSizeChange"
     @current-change="handleCurrentChange"
@@ -13,6 +14,9 @@
 </template>
 
 <script setup lang="ts" name="Pagination">
+import { useGlobalStore } from "@/stores/modules/global";
+const globalStore = useGlobalStore();
+
 interface Pageable {
   pageNum: number;
   pageSize: number;


### PR DESCRIPTION
当页面在包含有ProTable组建的页面时，首次修改组件大小报错
通过顶部修改组件大小组件 变更组件大小时会有’size‘相关报错
具体原因为element-plus 分页器组件不兼容全局组件大小变更功能