### PR TITLE
feat(component): 🚀 proTable支持插槽类型推断

### DIFF
--- a/src/components/ProTable/index.vue
+++ b/src/components/ProTable/index.vue
@@ -111,7 +111,7 @@ import { BreakPoint } from "@/components/Grid/interface";
 import { ColumnProps, TypeProps } from "@/components/ProTable/interface";
 import { Refresh, Operation, Search } from "@element-plus/icons-vue";
 import { generateUUID, handleProp } from "@/utils";
-import { ResultData } from "@/api/interface";
+import { ResultData, ResPage } from "@/api/interface";
 import SearchForm from "@/components/SearchForm/index.vue";
 import Pagination from "./components/Pagination.vue";
 import ColSetting from "./components/ColSetting.vue";
@@ -148,7 +148,10 @@ const props = withDefaults(defineProps<ProTableProps<T>>(), {
 
 // 定义slot的类型，支持泛型推断
 const slots = defineSlots<{
-  [key in keyof typeof slots]: (scope: { row: T extends ResultData ? T["data"][number] : T; $index: number }) => any;
+  [key in keyof typeof slots]: (scope: {
+    row: T extends ResultData<ResPage<any>> ? T["data"]["list"][number] : T extends ResultData ? T["data"] : T;
+    $index: number;
+  }) => any;
 }>();
 
 // table 实例

--- a/src/components/ProTable/interface/index.ts
+++ b/src/components/ProTable/interface/index.ts
@@ -83,4 +83,14 @@ export interface ColumnProps<T = any>
   _children?: ColumnProps<T>[]; // 多级表头
 }
 
-export type ProTableInstance = Omit<InstanceType<typeof ProTable>, keyof ComponentPublicInstance | keyof ProTableProps>;
+/**泛型组件出口类型 */
+export type GenericComponentExports<D extends (...p: any[]) => any> =
+  //这里获取组件通用类型
+  ComponentPublicInstance &
+    //这里获取defineExpose暴露的数据类型
+    Parameters<NonNullable<NonNullable<ReturnType<D>["__ctx"]>["expose"]>>[0];
+
+export type ProTableInstance = Omit<
+  GenericComponentExports<typeof ProTable>,
+  keyof ComponentPublicInstance | keyof ProTableProps<any>
+>;


### PR DESCRIPTION
bug关联 #509 
- 传入data推断出data的类型 
![image](https://github.com/user-attachments/assets/f55311e8-3a33-4497-97ee-25d6b4df8cca)

- 传入requestApi支持推断出api的返回data的类型
![image](https://github.com/user-attachments/assets/3cd3c55a-f026-483f-a7c2-846fe08a5938)
