### PR TITLE
菜单图标优化, 添加element-plus icon没有的图标 Update SubMenu.vue

### DIFF
--- a/src/layouts/components/Menu/SubMenu.vue
+++ b/src/layouts/components/Menu/SubMenu.vue
@@ -2,17 +2,41 @@
   <template v-for="subItem in menuList" :key="subItem.path">
     <el-sub-menu v-if="subItem.children?.length" :index="subItem.path">
       <template #title>
-        <el-icon v-if="subItem.meta.icon">
-          <component :is="subItem.meta.icon"></component>
-        </el-icon>
+        <!-- 处理图标 -->
+        <template v-if="subItem.meta.icon">
+          <template v-if="subItem.meta.icon.startsWith('svg-icon-')">
+            <SvgIcon
+              :name="subItem.meta.icon.replace('svg-icon-', '')"
+              :icon-style="{ width: '18px', height: '18px', marginRight: '5px' }"
+            />
+          </template>
+          <el-icon v-else>
+            <component :is="subItem.meta.icon" />
+          </el-icon>
+        </template>
+        <span v-else class="mr-[18px]"></span>
+        <!-- 标题 -->
         <span class="sle">{{ subItem.meta.title }}</span>
       </template>
       <SubMenu :menu-list="subItem.children" />
     </el-sub-menu>
+
     <el-menu-item v-else :index="subItem.path" @click="handleClickMenu(subItem)">
-      <el-icon v-if="subItem.meta.icon">
-        <component :is="subItem.meta.icon"></component>
-      </el-icon>
+      <!-- 处理图标 -->
+      <template v-if="subItem.meta.icon">
+        <template v-if="subItem.meta.icon.startsWith('svg-icon-')">
+          <SvgIcon
+            :name="subItem.meta.icon.replace('svg-icon-', '')"
+            :icon-style="{ width: '18px', height: '18px', marginRight: '5px' }"
+          />
+        </template>
+        <el-icon v-else>
+          <component :is="subItem.meta.icon" />
+        </el-icon>
+      </template>
+      <span v-else class="mr-[18px]"></span>
+
+      <!-- 标题 -->
       <template #title>
         <span class="sle">{{ subItem.meta.title }}</span>
       </template>


### PR DESCRIPTION
1. 如果没有图标则向右添加边距
2. 如果菜单想添加element-plus icon没有的图标, 则可以在icon目录新增, 然后图标字符串格式为svg-icon-新增图片名称
![image](https://github.com/user-attachments/assets/b8919cf4-c863-483b-adf4-9d161dfd62c9)
