### PR TITLE
fix:优化移动设备无法删除tab问题

### DIFF
--- a/src/layouts/components/Tabs/index.vue
+++ b/src/layouts/components/Tabs/index.vue
@@ -82,6 +82,11 @@ const tabsDrop = () => {
   Sortable.create(document.querySelector(".el-tabs__nav") as HTMLElement, {
     draggable: ".el-tabs__item",
     animation: 300,
+    delay: 50, // 调整为50ms延迟
+    delayOnTouchOnly: true,
+    touchStartThreshold: 3, // 降低触摸移动阈值
+    forceFallback: true, // 强制使用fallback实现
+    fallbackTolerance: 3, // 设置fallback容差
     onEnd({ newIndex, oldIndex }) {
       const tabsList = [...tabStore.tabsMenuList];
       const currRow = tabsList.splice(oldIndex as number, 1)[0];


### PR DESCRIPTION
移动设备操作删除tab时，点击很容易被识别成拖拽，故用AI帮忙修改了下，接着发现删除成功了但拖拽又不行了，故继续用AI修改，最终实现拖拽和删除都很轻松（在自己的安卓平板上进行了测试）